### PR TITLE
fix: preserve is_read value during async item processing

### DIFF
--- a/backend/internal/services/jobqueue.go
+++ b/backend/internal/services/jobqueue.go
@@ -91,9 +91,9 @@ func (s *jobQueueService) CompleteItem(ctx context.Context, itemID int32, title,
 	// Update the item with processed data, using the AI-extracted title and preserving URL
 	params := db.UpdateItemParams{
 		ID:          itemID,
-		Title:       title,    // Use AI-extracted title
-		Url:         item.Url, // Preserve existing URL
-		IsRead:      nil,
+		Title:       title,       // Use AI-extracted title
+		Url:         item.Url,    // Preserve existing URL
+		IsRead:      item.IsRead, // Preserve existing is_read value
 		TextContent: &textContent,
 		Summary:     &summary,
 		Type:        &itemType,


### PR DESCRIPTION
Fixed a bug in the CompleteItem function where the is_read field was being set to nil (NULL in database) instead of preserving the existing value. This was causing items processed asynchronously to lose their read status.

The fix ensures that when an item is completed after async processing, the existing is_read value is preserved rather than overwritten.

Fixes issue #28