### PR TITLE
feat: deleting and editing items

### DIFF
--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -45,6 +45,7 @@ type Querier interface {
 	GetUserPodcastStats(ctx context.Context, userID *int32) (GetUserPodcastStatsRow, error)
 	ListUsers(ctx context.Context) ([]User, error)
 	MarkItemAsRead(ctx context.Context, id int32) error
+	PatchItem(ctx context.Context, arg PatchItemParams) (Item, error)
 	RemoveItemFromPodcast(ctx context.Context, arg RemoveItemFromPodcastParams) error
 	ToggleItemReadStatus(ctx context.Context, id int32) (Item, error)
 	UpdateItem(ctx context.Context, arg UpdateItemParams) error

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -43,6 +43,7 @@ func (h *Handler) SetupRoutes(router *gin.Engine) {
 		itemGroup.GET("/user/:userID", h.GetItemsByUser)
 		itemGroup.GET("/user/:userID/unread", h.GetUnreadItemsByUser)
 		itemGroup.PUT("/:id", h.UpdateItem)
+		itemGroup.PATCH("/:id", h.PatchItem)
 		itemGroup.PATCH("/:id/read", h.MarkItemAsRead)
 		itemGroup.PATCH("/:id/toggle-read", h.ToggleItemReadStatus)
 		itemGroup.DELETE("/:id", h.DeleteItem)

--- a/backend/internal/handlers/items.go
+++ b/backend/internal/handlers/items.go
@@ -161,6 +161,35 @@ func (h *Handler) ToggleItemReadStatus(c *gin.Context) {
 	c.JSON(http.StatusOK, item)
 }
 
+func (h *Handler) PatchItem(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.ParseInt(idStr, 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid item ID"})
+		return
+	}
+
+	var req struct {
+		Title   *string  `json:"title"`
+		Summary *string  `json:"summary"`
+		Tags    []string `json:"tags"`
+		Authors []string `json:"authors"`
+	}
+
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	item, err := h.itemService.PatchItem(c.Request.Context(), int32(id), req.Title, req.Summary, req.Tags, req.Authors)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, item)
+}
+
 func (h *Handler) DeleteItem(c *gin.Context) {
 	idStr := c.Param("id")
 	id, err := strconv.ParseInt(idStr, 10, 32)

--- a/backend/internal/services/items.go
+++ b/backend/internal/services/items.go
@@ -20,6 +20,7 @@ type ItemService interface {
 	GetUnreadItemsByUser(ctx context.Context, userID *int32) ([]db.Item, error)
 	GetUnreadItemsFromPreviousDay(ctx context.Context) ([]db.Item, error)
 	UpdateItem(ctx context.Context, id int32, title string, url *string, textContent *string, summary *string, itemType *string, platform *string, tags []string, authors []string, isRead *bool) error
+	PatchItem(ctx context.Context, id int32, title *string, summary *string, tags []string, authors []string) (*db.Item, error)
 	MarkItemAsRead(ctx context.Context, id int32) error
 	ToggleItemReadStatus(ctx context.Context, id int32) (*db.Item, error)
 	DeleteItem(ctx context.Context, id int32) error
@@ -137,6 +138,21 @@ func (s *itemService) UpdateItem(ctx context.Context, id int32, title string, ur
 		Authors:     authors,
 	}
 	return s.querier.UpdateItem(ctx, params)
+}
+
+func (s *itemService) PatchItem(ctx context.Context, id int32, title *string, summary *string, tags []string, authors []string) (*db.Item, error) {
+	params := db.PatchItemParams{
+		ID:      id,
+		Title:   title,
+		Summary: summary,
+		Tags:    tags,
+		Authors: authors,
+	}
+	item, err := s.querier.PatchItem(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	return &item, nil
 }
 
 func (s *itemService) MarkItemAsRead(ctx context.Context, id int32) error {

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,6 +5,7 @@
       "name": "frontend",
       "dependencies": {
         "@faker-js/faker": "^9.6.0",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -296,6 +297,8 @@
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
+
+    "@radix-ui/react-alert-dialog": ["@radix-ui/react-alert-dialog@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dialog": "1.1.15", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw=="],
 
     "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^9.6.0",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,155 @@
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -9,14 +9,13 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",

--- a/frontend/src/routes/items.$id.tsx
+++ b/frontend/src/routes/items.$id.tsx
@@ -1,10 +1,13 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { itemApi } from "@/services/api";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, Calendar, ExternalLink, Tag, User } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { ArrowLeft, Calendar, ExternalLink, Tag, User, Edit2, X, Check } from "lucide-react";
 import { formatRelativeDate } from "@/lib/date-utils";
+import { useState } from "react";
 
 export const Route = createFileRoute("/items/$id")({
 	component: ItemDetailPage,
@@ -13,6 +16,14 @@ export const Route = createFileRoute("/items/$id")({
 function ItemDetailPage() {
 	const navigate = useNavigate();
 	const { id } = Route.useParams();
+	const queryClient = useQueryClient();
+	const [isEditing, setIsEditing] = useState(false);
+	const [editForm, setEditForm] = useState({
+		title: "",
+		summary: "",
+		tags: [] as string[],
+		authors: [] as string[],
+	});
 
 	const {
 		data: item,
@@ -26,6 +37,40 @@ function ItemDetailPage() {
 		},
 		enabled: !!id,
 	});
+
+	const patchMutation = useMutation({
+		mutationFn: (data: Partial<{ title: string; summary: string; tags: string[]; authors: string[] }>) =>
+			itemApi.patchItem(parseInt(id), data),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["item", id] });
+			setIsEditing(false);
+		},
+	});
+
+	const handleEdit = () => {
+		setEditForm({
+			title: item?.title || "",
+			summary: item?.summary || "",
+			tags: item?.tags || [],
+			authors: item?.authors || [],
+		});
+		setIsEditing(true);
+	};
+
+	const handleCancel = () => {
+		setIsEditing(false);
+	};
+
+	const handleSave = () => {
+		const updates: Partial<{ title: string; summary: string; tags: string[]; authors: string[] }> = {};
+
+		if (editForm.title !== item?.title) updates.title = editForm.title;
+		if (editForm.summary !== item?.summary) updates.summary = editForm.summary;
+		if (JSON.stringify(editForm.tags) !== JSON.stringify(item?.tags)) updates.tags = editForm.tags;
+		if (JSON.stringify(editForm.authors) !== JSON.stringify(item?.authors)) updates.authors = editForm.authors;
+
+		patchMutation.mutate(updates);
+	};
 
 	if (isLoading) {
 		return (
@@ -84,14 +129,33 @@ function ItemDetailPage() {
 		<div className="container mx-auto py-8 max-w-4xl">
 			{/* Header with back button */}
 			<div className="mb-8">
-				<Button
-					onClick={() => navigate({ to: "/" })}
-					variant="ghost"
-					className="mb-4"
-				>
-					<ArrowLeft className="mr-2 h-4 w-4" />
-					Back to Items
-				</Button>
+				<div className="flex items-center justify-between">
+					<Button
+						onClick={() => navigate({ to: "/" })}
+						variant="ghost"
+						className="mb-4"
+					>
+						<ArrowLeft className="mr-2 h-4 w-4" />
+						Back to Items
+					</Button>
+					{!isEditing ? (
+						<Button onClick={handleEdit} variant="outline" size="sm">
+							<Edit2 className="mr-2 h-4 w-4" />
+							Edit
+						</Button>
+					) : (
+						<div className="flex gap-2">
+							<Button onClick={handleSave} variant="default" size="sm" disabled={patchMutation.isPending}>
+								<Check className="mr-2 h-4 w-4" />
+								Save
+							</Button>
+							<Button onClick={handleCancel} variant="outline" size="sm">
+								<X className="mr-2 h-4 w-4" />
+								Cancel
+							</Button>
+						</div>
+					)}
+				</div>
 			</div>
 
 			{/* Item Details - Clean Layout */}
@@ -100,9 +164,18 @@ function ItemDetailPage() {
 				<div>
 					<div className="flex items-start justify-between mb-4">
 						<div className="space-y-2 flex-1">
-							<h1 className="text-3xl font-bold text-foreground">
-								{item.title || "Untitled Item"}
-							</h1>
+							{isEditing ? (
+								<Input
+									value={editForm.title}
+									onChange={(e) => setEditForm({ ...editForm, title: e.target.value })}
+									className="text-3xl font-bold"
+									placeholder="Item title"
+								/>
+							) : (
+								<h1 className="text-3xl font-bold text-foreground">
+									{item.title || "Untitled Item"}
+								</h1>
+							)}
 							{item.url && (
 								<p className="text-sm text-muted-foreground">
 									<a
@@ -150,48 +223,142 @@ function ItemDetailPage() {
 				</div>
 
 				{/* Authors */}
-				{item.authors && item.authors.length > 0 && (
+				{(item.authors && item.authors.length > 0) || isEditing ? (
 					<div>
 						<h2 className="text-xl font-semibold flex items-center gap-2 mb-3">
 							<User className="h-5 w-5" />
 							Authors
 						</h2>
-						<div className="flex flex-wrap gap-2">
-							{item.authors.map((author, index) => (
-								<Badge key={index} variant="secondary">
-									{author}
-								</Badge>
-							))}
-						</div>
+						{isEditing ? (
+							<div className="space-y-2">
+								<div className="flex flex-wrap gap-2">
+									{editForm.authors.map((author, index) => (
+										<Badge key={index} variant="secondary" className="flex items-center gap-1 pr-1">
+											{author}
+											<button
+												onClick={() =>
+													setEditForm({
+														...editForm,
+														authors: editForm.authors.filter((_, i) => i !== index),
+													})
+												}
+												className="ml-1 hover:bg-background/50 rounded-sm p-0.5"
+											>
+												<X className="h-3 w-3" />
+											</button>
+										</Badge>
+									))}
+								</div>
+								<div className="flex gap-2">
+									<Input
+										placeholder="Add author and press Enter"
+										onKeyDown={(e) => {
+											if (e.key === "Enter") {
+												e.preventDefault();
+												const input = e.currentTarget;
+												const value = input.value.trim();
+												if (value && !editForm.authors.includes(value)) {
+													setEditForm({
+														...editForm,
+														authors: [...editForm.authors, value],
+													});
+													input.value = "";
+												}
+											}
+										}}
+									/>
+								</div>
+							</div>
+						) : (
+							<div className="flex flex-wrap gap-2">
+								{item.authors.map((author, index) => (
+									<Badge key={index} variant="secondary">
+										{author}
+									</Badge>
+								))}
+							</div>
+						)}
 					</div>
-				)}
+				) : null}
 
 				{/* Tags */}
-				{item.tags && item.tags.length > 0 && (
+				{(item.tags && item.tags.length > 0) || isEditing ? (
 					<div>
 						<h2 className="text-xl font-semibold flex items-center gap-2 mb-3">
 							<Tag className="h-5 w-5" />
 							Tags
 						</h2>
-						<div className="flex flex-wrap gap-2">
-							{item.tags.map((tag, index) => (
-								<Badge key={index} variant="secondary">
-									{tag}
-								</Badge>
-							))}
-						</div>
+						{isEditing ? (
+							<div className="space-y-2">
+								<div className="flex flex-wrap gap-2">
+									{editForm.tags.map((tag, index) => (
+										<Badge key={index} variant="secondary" className="flex items-center gap-1 pr-1">
+											{tag}
+											<button
+												onClick={() =>
+													setEditForm({
+														...editForm,
+														tags: editForm.tags.filter((_, i) => i !== index),
+													})
+												}
+												className="ml-1 hover:bg-background/50 rounded-sm p-0.5"
+											>
+												<X className="h-3 w-3" />
+											</button>
+										</Badge>
+									))}
+								</div>
+								<div className="flex gap-2">
+									<Input
+										placeholder="Add tag and press Enter"
+										onKeyDown={(e) => {
+											if (e.key === "Enter") {
+												e.preventDefault();
+												const input = e.currentTarget;
+												const value = input.value.trim();
+												if (value && !editForm.tags.includes(value)) {
+													setEditForm({
+														...editForm,
+														tags: [...editForm.tags, value],
+													});
+													input.value = "";
+												}
+											}
+										}}
+									/>
+								</div>
+							</div>
+						) : (
+							<div className="flex flex-wrap gap-2">
+								{item.tags.map((tag, index) => (
+									<Badge key={index} variant="secondary">
+										{tag}
+									</Badge>
+								))}
+							</div>
+						)}
 					</div>
-				)}
+				) : null}
 
 				{/* Summary */}
-				{item.summary && (
+				{item.summary || isEditing ? (
 					<div>
 						<h2 className="text-xl font-semibold mb-3">Summary</h2>
-						<p className="text-muted-foreground leading-relaxed">
-							{item.summary}
-						</p>
+						{isEditing ? (
+							<Textarea
+								value={editForm.summary}
+								onChange={(e) => setEditForm({ ...editForm, summary: e.target.value })}
+								placeholder="Enter summary"
+								rows={6}
+								className="w-full"
+							/>
+						) : (
+							<p className="text-muted-foreground leading-relaxed">
+								{item.summary}
+							</p>
+						)}
 					</div>
-				)}
+				) : null}
 			</div>
 		</div>
 	);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -91,6 +91,11 @@ export const itemApi = {
     await api.put(`/items/${id}`, data)
   },
 
+  patchItem: async (id: number, data: Partial<{ title: string; summary: string; tags: string[]; authors: string[] }>): Promise<Item> => {
+    const response = await api.patch<Item>(`/items/${id}`, data)
+    return response.data
+  },
+
   markItemAsRead: async (id: number): Promise<Item> => {
     const response = await api.patch<Item>(`/items/${id}/read`)
     return response.data


### PR DESCRIPTION
Adds the ability to edit item metadata (title, tags, authors, summary) and delete items from both the item detail page and the items table.

## Backend Changes
  - New PATCH endpoint (PATCH /items/:id) for partial item updates
    - Added PatchItem SQL query with named parameters using sqlc.arg and sqlc.narg
    - Only updates fields that are provided (supports partial updates)
    - Added service method and handler for patching items
    - Generated sqlc code for new query

## Frontend Changes
### Item Detail Page (items.$id.tsx)
  - Edit mode with inline editing for:
    - Title (text input)
    - Summary (textarea)
    - Tags (add/remove individual badges)
    - Authors (add/remove individual badges)
  - Delete button with confirmation dialog
  - Edit/Save/Cancel workflow
  - Only sends changed fields to backend
### Items Table (index route)
  - New Actions column with delete button
  - Trash icon for each item row
  - Confirmation dialog before deletion
  - Automatic table refresh after deletion
 ### Tag/Author Editing UX
  - Improved from comma-separated input to badge-based editing
  - Press Enter to add new tag/author
  - Click X on badge to remove
  - Prevents duplicate entries
  - No parsing issues with commas
## API Changes
  - Added patchItem method to frontend API service
  - Accepts partial updates: { title?, summary?, tags?, authors? }
## Technical Details
  - Uses React Query mutations with optimistic cache invalidation
  - Shadcn AlertDialog component for delete confirmations
  - Button variant="destructive" for delete actions
  - Proper error handling and loading states